### PR TITLE
Add graham GCC arch files for StdEnv/2023 compilers

### DIFF
--- a/ALLIANCE/arch-GCC_GRAHAM.env
+++ b/ALLIANCE/arch-GCC_GRAHAM.env
@@ -1,0 +1,6 @@
+module load StdEnv/2023
+module load hdf5-mpi/1.14.2
+module load netcdf-mpi/4.9.2
+module load netcdf-c++4-mpi/4.3.1
+module load netcdf-fortran-mpi/4.6.1
+module load perl/5.36.1

--- a/ALLIANCE/arch-GCC_GRAHAM.fcm
+++ b/ALLIANCE/arch-GCC_GRAHAM.fcm
@@ -1,0 +1,24 @@
+################################################################################
+###################       Project xios - xmlioserver       #####################
+################################################################################
+
+%CCOMPILER      mpicc
+%FCOMPILER      mpif90
+%LINKER         mpif90
+
+%BASE_CFLAGS    -ansi -w -std=gnu++11
+%PROD_CFLAGS    -O3 -DBOOST_DISABLE_ASSERTS
+%DEV_CFLAGS     -g -O2
+%DEBUG_CFLAGS   -g
+
+%BASE_FFLAGS    -D__NONE__
+%PROD_FFLAGS    -O3
+%DEV_FFLAGS     -g -O2
+%DEBUG_FFLAGS   -g
+
+%BASE_INC       -D__NONE__
+%BASE_LD        -lstdc++
+
+%CPP            cpp
+%FPP            cpp -P
+%MAKE           gmake

--- a/ALLIANCE/arch-GCC_GRAHAM.path
+++ b/ALLIANCE/arch-GCC_GRAHAM.path
@@ -1,0 +1,2 @@
+NETCDF_LIB="-lnetcdf -lnetcdff"
+HDF5_LIB="-lhdf5_hl -lhdf5 -lz"

--- a/ALLIANCE/arch-X64_GRAHAM.env
+++ b/ALLIANCE/arch-X64_GRAHAM.env
@@ -1,6 +1,7 @@
-module load StdEnv/2020
-module load hdf5-mpi/1.10.6
+module load StdEnv/2023
+module load intel/2023.2.1
+module load hdf5-mpi/1.14.2
+module load netcdf-mpi/4.9.2
 module load netcdf-c++4-mpi/4.3.1
-module load netcdf-fortran-mpi/4.6.0
-module load netcdf-mpi/4.7.4
-module load perl/5.30.2
+module load netcdf-fortran-mpi/4.6.1
+module load perl/5.36.1

--- a/ALLIANCE/arch-X64_GRAHAM.fcm
+++ b/ALLIANCE/arch-X64_GRAHAM.fcm
@@ -6,7 +6,7 @@
 %FCOMPILER      mpif90
 %LINKER         mpif90
 
-%BASE_CFLAGS    -diag-disable 1125 -diag-disable 279 -D_GLIBCXX_USE_CXX11_ABI=0 -std=c++11
+%BASE_CFLAGS    -std=c++11
 %PROD_CFLAGS    -O3 -D BOOST_DISABLE_ASSERTS
 %DEV_CFLAGS     -g -traceback
 %DEBUG_CFLAGS   -DBZ_DEBUG -g -traceback -fno-inline


### PR DESCRIPTION
`StdEnv/2023` becomes the default environment on `graham` on 3-Apr-2024. The major change is that the GCC 12.3 compiler collection becomes the default, instead of Intel.

Environment details: https://docs.alliancecan.ca/wiki/Standard_software_environments

After the addition of 2 include statements to `extern/remap/src/meshutil.cpp`, the build of XIOS-2 was successful.